### PR TITLE
Update deployment details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd dash-rq-demo
 If you have [Docker][docker] installed, run the app with
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
 The app can be accessed at [localhost:8050](https://127.0.0.1:8050).
@@ -48,12 +48,12 @@ server so that you can benefit from hot-reloading without rebuilding the
 container.
 
 ```sh
-docker-compose -f docker-compose.dev.yml up
+docker compose -f docker-compose.dev.yml up
 ```
 ### Run manually
 
 If you don't want to use Docker, first make sure you have
-[Python>=3.6][python36] and [Redis][redis] installed. Once you've done this you
+[Python>=3.7][python37] and [Redis][redis] installed. Once you've done this you
 will need to [start a Redis server][redis-server]. See the links for more
 details, but probably you will want to run something like:
 
@@ -78,26 +78,46 @@ To deploy your own copy of this app on Heroku, just click on this button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)][deploy-endpoint]
 
+**Note**: you may need to wait a few minutes for the Redis addon to start before the app starts working.
+
 Alternatively if you would like to set things up manually, follow the below
 steps. You will need to install the [Heroku CLI][heroku-cli].
 
-Note we need to add the Redis addon, and also use `heroku scale worker=1` to
-start a worker for processing the queue in the background.
+First clone this repository and navigate to it
 
 ```sh
-# clone repo to your local machine
 git clone https://github.com/tcbegley/dash-rq-demo.git
 cd dash-rq-demo
+```
 
-# create heroku app and push code to heroku repo
+Create a new Heroku app and push the contents of this repository
+
+```sh
 heroku create
 git push heroku main
+```
 
-# create redis add-on and background worker
-heroku addons:create redistogo
+Create the Redis addon, note that this can take a few minutes to start.
+
+```sh
+heroku addons:create heroku-redis:hobby-dev
+```
+
+You can check the status of the addon with the following command. The app will not work until the addon has been successfully created.
+
+```sh
+heroku addons:info heroku-redis
+```
+
+Add a worker to handle the background tasks.
+
+```sh
 heroku scale worker=1
+```
 
-# open the deployed app in your browser
+Open the deployed app in your browser
+
+```sh
 heroku open
 ```
 
@@ -111,7 +131,7 @@ request.
 [docker]: https://www.docker.com/
 [heroku]: https://www.heroku.com/
 [heroku-cli]: https://devcenter.heroku.com/articles/heroku-cli
-[python36]: https://www.python.org/
+[python37]: https://www.python.org/
 [redis]: https://redis.io/
 [redis-server]: https://redis.io/topics/quickstart#starting-redis
 [rq-docs]: https://python-rq.org/

--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "keywords": ["flask", "plotly-dash", "python", "rq", "redis"],
   "website": "https://dash-rq-demo.herokuapp.com/",
   "repository": "https://github.com/tcbegley/dash-rq-demo",
+  "stack": "heroku-22",
   "addons": ["redistogo"],
   "formation": {
     "web": { "quantity": 1, "size": "free" },

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "website": "https://dash-rq-demo.herokuapp.com/",
   "repository": "https://github.com/tcbegley/dash-rq-demo",
   "stack": "heroku-22",
-  "addons": ["redistogo"],
+  "addons": ["heroku-redis"],
   "formation": {
     "web": { "quantity": 1, "size": "free" },
     "worker": { "quantity": 1, "size": "free" }

--- a/dash_rq_demo/__init__.py
+++ b/dash_rq_demo/__init__.py
@@ -1,11 +1,8 @@
 import uuid
 from collections import namedtuple
 
-import dash
 import dash_bootstrap_components as dbc
-import dash_core_components as dcc
-import dash_html_components as html
-from dash.dependencies import Input, Output, State
+from dash import Input, Output, State, dcc, html, no_update
 from rq.exceptions import NoSuchJobError
 from rq.job import Job
 
@@ -103,7 +100,7 @@ def retrieve_output(n, submitted):
                 result=f"Processing - {progress:.1f}% complete",
                 progress=progress,
                 collapse_is_open=True,
-                finished_data=dash.no_update,
+                finished_data=no_update,
             )
         except NoSuchJobError:
             # something went wrong, display a simple error message
@@ -111,7 +108,7 @@ def retrieve_output(n, submitted):
                 result="Error: result not found...",
                 progress=None,
                 collapse_is_open=False,
-                finished_data=dash.no_update,
+                finished_data=no_update,
             )
     # nothing submitted yet, return nothing.
     return Result(

--- a/dash_rq_demo/core.py
+++ b/dash_rq_demo/core.py
@@ -1,20 +1,21 @@
 import os
 
-import dash
 import dash_bootstrap_components as dbc
 import flask
 import redis
+from dash import Dash
 from rq import Queue
 
 server = flask.Flask(__name__)
 
-app = dash.Dash(
+app = Dash(
     server=server,
     external_stylesheets=[dbc.themes.BOOTSTRAP],
     serve_locally=False,
 )
 
-# redis connection and RQ queue. use redistogo service when dpeloying to Heroku
-redis_url = os.getenv("REDISTOGO_URL", "redis://localhost:6379")
+# redis connection and RQ queue
+# use heroku-redis service when deploying to Heroku
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
 conn = redis.from_url(redis_url)
 queue = Queue(connection=conn)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       sh -c "python worker.py &
              python run_locally.py"
     environment:
-      - REDISTOGO_URL=redis://redis:6379
+      - REDIS_URL=redis://redis:6379
       - APP_HOST=0.0.0.0
     depends_on:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       sh -c "python worker.py &
              gunicorn dash_rq_demo.wsgi -b 0.0.0.0:8050 -w 2"
     environment:
-      - REDISTOGO_URL=redis://redis:6379
+      - REDIS_URL=redis://redis:6379
     depends_on:
       - redis
     ports:


### PR DESCRIPTION
This app was previously deployed on the Heroku-18 stack which has been deprecated. Additionally it used RedisToGo which is shutting down.

These updates fix those issues and a few more such as Dash import syntax and Docker CLI commands in the README.